### PR TITLE
Merge forks331 into master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "3.3.0",
+  "version": "3.1.1",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {

--- a/src/ecsignature.js
+++ b/src/ecsignature.js
@@ -47,7 +47,7 @@ ECSignature.fromDER = function (buffer) {
 // BIP62: 1 byte hashType flag (only 0x01, 0x02, 0x03, 0x81, 0x82 and 0x83 are allowed)
 ECSignature.parseScriptSignature = function (buffer) {
   var hashType = buffer.readUInt8(buffer.length - 1)
-  var hashTypeMod = hashType & ~0x80
+  var hashTypeMod = hashType & ~0xc0
 
   if (hashTypeMod <= 0x00 || hashTypeMod >= 0x04) throw new Error('Invalid hashType ' + hashType)
 
@@ -85,7 +85,7 @@ ECSignature.prototype.toRSBuffer = function (buffer, offset) {
 }
 
 ECSignature.prototype.toScriptSignature = function (hashType) {
-  var hashTypeMod = hashType & ~0x80
+  var hashTypeMod = hashType & ~0xc0
   if (hashTypeMod <= 0 || hashTypeMod >= 4) throw new Error('Invalid hashType ' + hashType)
 
   var hashTypeBuffer = Buffer.alloc(1)

--- a/src/networks.js
+++ b/src/networks.js
@@ -2,6 +2,16 @@
 // Dogecoin BIP32 is a proposed standard: https://bitcointalk.org/index.php?topic=409731
 
 module.exports = {
+  bitcoingold: {
+    messagePrefix: '\x18Bitcoin Gold Signed Message:\n',
+    bip32: {
+      public: 0x0488b21e,
+      private: 0x0488ade4
+    },
+    pubKeyHash: 0x26,
+    scriptHash: 0x17,
+    wif: 0x80
+  },
   bitcoin: {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     bech32: 'bc',

--- a/src/script.js
+++ b/src/script.js
@@ -185,7 +185,7 @@ function isCanonicalPubKey (buffer) {
 }
 
 function isDefinedHashType (hashType) {
-  var hashTypeMod = hashType & ~0x80
+  var hashTypeMod = hashType & ~0xc0
 
 // return hashTypeMod > SIGHASH_ALL && hashTypeMod < SIGHASH_SINGLE
   return hashTypeMod > 0x00 && hashTypeMod < 0x04

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -174,7 +174,7 @@ function expandInput (scriptSig, witnessStack) {
 }
 
 // could be done in expandInput, but requires the original Transaction for hashForSignature
-function fixMultisigOrder (input, transaction, vin) {
+function fixMultisigOrder (input, transaction, vin, value, forkId) {
   if (input.redeemScriptType !== scriptTypes.MULTISIG || !input.redeemScript) return
   if (input.pubKeys.length === input.signatures.length) return
 
@@ -191,7 +191,22 @@ function fixMultisigOrder (input, transaction, vin) {
 
       // TODO: avoid O(n) hashForSignature
       var parsed = ECSignature.parseScriptSignature(signature)
-      var hash = transaction.hashForSignature(vin, input.redeemScript, parsed.hashType)
+      var hash
+      switch (forkId) {
+        case Transaction.FORKID_BCH:
+          hash = transaction.hashForCashSignature(vin, input.signScript, value, parsed.hashType)
+          break
+        case Transaction.FORKID_BTG:
+          hash = transaction.hashForGoldSignature(vin, input.signScript, value, parsed.hashType)
+          break
+        default:
+          if (input.witness) {
+            hash = transaction.hashForWitnessV0(vin, input.signScript, value, parsed.hashType)
+          } else {
+            hash = transaction.hashForSignature(vin, input.signScript, parsed.hashType)
+          }
+          break
+      }
 
       // skip if signature does not match pubKey
       if (!keyPair.verify(hash, parsed.signature)) return false
@@ -448,7 +463,6 @@ function buildInput (input, allowIncomplete) {
         witness.push(input.witnessScript)
         scriptType = input.witnessScriptType
       }
-
       break
   }
 
@@ -469,10 +483,28 @@ function TransactionBuilder (network, maximumFeeRate) {
   this.network = network || networks.bitcoin
 
   // WARNING: This is __NOT__ to be relied on, its just another potential safety mechanism (safety in-depth)
-  this.maximumFeeRate = maximumFeeRate || 1000
+  this.maximumFeeRate = maximumFeeRate || 2500
 
   this.inputs = []
+  this.bitcoinCash = false
+  this.bitcoinGold = false
   this.tx = new Transaction()
+}
+
+TransactionBuilder.prototype.enableBitcoinCash = function (enable) {
+  if (typeof enable === 'undefined') {
+    enable = true
+  }
+
+  this.bitcoinCash = enable
+}
+
+TransactionBuilder.prototype.enableBitcoinGold = function (enable) {
+  if (typeof enable === 'undefined') {
+    enable = true
+  }
+
+  this.bitcoinGold = enable
 }
 
 TransactionBuilder.prototype.setLockTime = function (locktime) {
@@ -497,8 +529,16 @@ TransactionBuilder.prototype.setVersion = function (version) {
   this.tx.version = version
 }
 
-TransactionBuilder.fromTransaction = function (transaction, network) {
+TransactionBuilder.fromTransaction = function (transaction, network, forkId) {
   var txb = new TransactionBuilder(network)
+
+  if (typeof forkId === 'number') {
+    if (forkId === Transaction.FORKID_BTG) {
+      txb.enableBitcoinGold(true)
+    } else if (forkId === Transaction.FORKID_BCH) {
+      txb.enableBitcoinCash(true)
+    }
+  }
 
   // Copy transaction fields
   txb.setVersion(transaction.version)
@@ -514,13 +554,14 @@ TransactionBuilder.fromTransaction = function (transaction, network) {
     txb.__addInputUnsafe(txIn.hash, txIn.index, {
       sequence: txIn.sequence,
       script: txIn.script,
-      witness: txIn.witness
+      witness: txIn.witness,
+      value: txIn.value
     })
   })
 
   // fix some things not possible through the public API
   txb.inputs.forEach(function (input, i) {
-    fixMultisigOrder(input, transaction, i)
+    fixMultisigOrder(input, transaction, i, input.value, forkId)
   })
 
   return txb
@@ -695,10 +736,16 @@ TransactionBuilder.prototype.sign = function (vin, keyPair, redeemScript, hashTy
 
   // ready to sign
   var signatureHash
-  if (input.witness) {
-    signatureHash = this.tx.hashForWitnessV0(vin, input.signScript, input.value, hashType)
+  if (this.bitcoinGold) {
+    signatureHash = this.tx.hashForGoldSignature(vin, input.signScript, witnessValue, hashType, input.witness)
+  } else if (this.bitcoinCash) {
+    signatureHash = this.tx.hashForCashSignature(vin, input.signScript, witnessValue, hashType)
   } else {
-    signatureHash = this.tx.hashForSignature(vin, input.signScript, hashType)
+    if (input.witness) {
+      signatureHash = this.tx.hashForWitnessV0(vin, input.signScript, witnessValue, hashType)
+    } else {
+      signatureHash = this.tx.hashForSignature(vin, input.signScript, hashType)
+    }
   }
 
   // enforce in order signing of public keys

--- a/test/bitcoincash.test.js
+++ b/test/bitcoincash.test.js
@@ -1,0 +1,37 @@
+/* global describe, it */
+
+var assert = require('assert')
+var bscript = require('../src/script')
+var ECPair = require('../src/ecpair')
+var NETWORKS = require('../src/networks')
+var TransactionBuilder = require('../src/transaction_builder')
+var Transaction = require('../src/transaction')
+
+describe('TransactionBuilder', function () {
+  var network = NETWORKS['testnet']
+  it('cashtestcase3', function () {
+    var value = 50 * 1e8
+    var txid = '40c8a218923f23df3692530fa8e475251c50c7d630dccbdfbd92ba8092f4aa13'
+    var vout = 0
+
+    var wif = 'cTNwkxh7nVByhc3i7BH6eaBFQ4yVs6WvXBGBoA9xdKiorwcYVACc'
+    var keyPair = ECPair.fromWIF(wif, network)
+
+    var pk = keyPair.getPublicKeyBuffer()
+    var spk = bscript.pubKey.output.encode(pk)
+
+    var txb = new TransactionBuilder(network)
+    txb.addInput(txid, vout, Transaction.DEFAULT_SEQUENCE, spk)
+    txb.addOutput('mzDktdwPcWwqg8aZkPotx6aYi4mKvDD7ay', value)
+    txb.enableBitcoinCash(true)
+    txb.setVersion(2)
+
+    var hashType = Transaction.SIGHASH_ALL | Transaction.SIGHASH_BITCOINCASHBIP143
+
+    txb.sign(0, keyPair, null, hashType, value)
+
+    var tx = txb.build()
+    var hex = tx.toHex()
+    assert.equal('020000000113aaf49280ba92bddfcbdc30d6c7501c2575e4a80f539236df233f9218a2c8400000000049483045022100c5874e39da4dd427d35e24792bf31dcd63c25684deec66b426271b4043e21c3002201bfdc0621ad4237e8db05aa6cad69f3d5ab4ae32ebb2048f65b12165da6cc69341ffffffff0100f2052a010000001976a914cd29cc97826c37281ac61301e4d5ed374770585688ac00000000', hex)
+  })
+})

--- a/test/bitcoingold.test.js
+++ b/test/bitcoingold.test.js
@@ -1,0 +1,76 @@
+/* global describe, it */
+
+var assert = require('assert')
+var bscript = require('../src/script')
+var bcrypto = require('../src/crypto')
+var ECPair = require('../src/ecpair')
+var NETWORKS = require('../src/networks')
+var TransactionBuilder = require('../src/transaction_builder')
+var Transaction = require('../src/transaction')
+
+describe('TransactionBuilder', function () {
+  var network = NETWORKS['bitcoingold']
+  it('goldtestcase', function () {
+    var value = 50 * 1e8
+    var txid = '40c8a218923f23df3692530fa8e475251c50c7d630dccbdfbd92ba8092f4aa13'
+    var vout = 0
+
+    var wif = 'L54PmHcjKXi8H6v9cLAJ7DgGJFDpaFpR2YsV2WARieb82dz3QAfr'
+    var keyPair = ECPair.fromWIF(wif, network)
+
+    var pk = bcrypto.hash160(keyPair.getPublicKeyBuffer())
+    var spk = bscript.pubKeyHash.output.encode(pk)
+
+    var txb = new TransactionBuilder(network)
+    txb.addInput(txid, vout, Transaction.DEFAULT_SEQUENCE, spk)
+    txb.addOutput('GfEHv6hKvAX8HYfFzabMY2eiYDtC9eViqe', value)
+    txb.enableBitcoinGold(true)
+    txb.setVersion(2)
+
+    var hashType = Transaction.SIGHASH_ALL | Transaction.SIGHASH_BITCOINCASHBIP143
+
+    txb.sign(0, keyPair, null, hashType, value)
+
+    var tx = txb.build()
+    var hex = tx.toHex()
+    assert.equal('020000000113aaf49280ba92bddfcbdc30d6c7501c2575e4a80f539236df233f9218a2c840000000006b483045022100c594c8e0750b1b6ec4e267b6d6c7098840f86fa9467f8aa452f439c3a72e0cd9022019759d800fffd7fcb78d16468f5693ea07a13da33607e0e8fbb4cdb5967075b441210201ad6a9a15457b162a71f1d5db8fe27ff001abc4ae3a888214f9407cb0da863cffffffff0100f2052a010000001976a914ea95bd5087d3b5f2df279304a46ad827225c4e8688ac00000000', hex)
+  })
+
+  it('goldtestcase_multisig_1', function () {
+    var value = 50 * 1e8
+
+    var txHex = '020000000113aaf49280ba92bddfcbdc30d6c7501c2575e4a80f539236df233f9218a2c840000000009200483045022100b3b4211b8e8babc667dcca0b6f1c1284f191170a38a59bc3b9d7541d68c3c7a002200196267b87a7b80f3f556b3372e5ee6ed19b4b9e802c34916f45bc2b11d2de1a414752210201ad6a9a15457b162a71f1d5db8fe27ff001abc4ae3a888214f9407cb0da863c2103e6533849994cf76a9009447f2ad6dbf84c78e6f5f48fe77cf83cd9a3fe2e30ec52aeffffffff0100f2052a010000001976a914ea95bd5087d3b5f2df279304a46ad827225c4e8688ac00000000'
+    var tx = Transaction.fromHex(txHex)
+    tx.ins[0].value = value
+
+    var txb = TransactionBuilder.fromTransaction(tx, network, Transaction.FORKID_BTG)
+
+    assert.equal(undefined, txb.inputs[0].signatures[0])
+    assert.equal(
+      '3045022100b3b4211b8e8babc667dcca0b6f1c1284f191170a38a59bc3b9d7541d68c3c7a002200196267b87a7b80f3f556b3372e5ee6ed19b4b9e802c34916f45bc2b11d2de1a41',
+      txb.inputs[0].signatures[1].toString('hex')
+    )
+
+    var hex = txb.build().toHex()
+    assert.equal(txHex, hex)
+  })
+
+  it('goldtestcase_multisig_0', function () {
+    var value = 50 * 1e8
+
+    var txHex = '020000000113aaf49280ba92bddfcbdc30d6c7501c2575e4a80f539236df233f9218a2c840000000009100473044022025cb6ee7a63c7403645be2ed4ffcf9cd41d773ee3ba57a05dc335c4427f647660220323a038daac698efdc700ffa8d90e6641ed9eb4ab82808df0506a9da08863d29414752210201ad6a9a15457b162a71f1d5db8fe27ff001abc4ae3a888214f9407cb0da863c2103e6533849994cf76a9009447f2ad6dbf84c78e6f5f48fe77cf83cd9a3fe2e30ec52aeffffffff0100f2052a010000001976a914ea95bd5087d3b5f2df279304a46ad827225c4e8688ac00000000'
+    var tx = Transaction.fromHex(txHex)
+    tx.ins[0].value = value
+
+    var txb = TransactionBuilder.fromTransaction(tx, network, Transaction.FORKID_BTG)
+
+    assert.equal(
+      '3044022025cb6ee7a63c7403645be2ed4ffcf9cd41d773ee3ba57a05dc335c4427f647660220323a038daac698efdc700ffa8d90e6641ed9eb4ab82808df0506a9da08863d2941',
+      txb.inputs[0].signatures[0].toString('hex')
+    )
+    assert.equal(undefined, txb.inputs[0].signatures[1])
+
+    var hex = txb.build().toHex()
+    assert.equal(txHex, hex)
+  })
+})

--- a/test/integration/_mainnet.js
+++ b/test/integration/_mainnet.js
@@ -1,0 +1,3 @@
+var Blockchain = require('cb-http-client')
+var BLOCKTRAIL_API_KEY = process.env.BLOCKTRAIL_API_KEY || 'c0bd8155c66e3fb148bb1664adc1e4dacd872548'
+module.exports = new Blockchain('https://api.blocktrail.com/cb/v0.2.1/BTC', { api_key: BLOCKTRAIL_API_KEY })

--- a/test/integration/_testnet.js
+++ b/test/integration/_testnet.js
@@ -1,0 +1,99 @@
+var async = require('async')
+var bitcoin = require('../../')
+var Blockchain = require('cb-http-client')
+var coinSelect = require('coinselect')
+var dhttp = require('dhttp/200')
+var typeforce = require('typeforce')
+var types = require('../../src/types')
+
+var BLOCKTRAIL_API_KEY = process.env.BLOCKTRAIL_API_KEY || 'c0bd8155c66e3fb148bb1664adc1e4dacd872548'
+var blockchain = new Blockchain('https://api.blocktrail.com/cb/v0.2.1/tBTC', { api_key: BLOCKTRAIL_API_KEY })
+var kpNetwork = bitcoin.networks.testnet
+var keyPair = bitcoin.ECPair.fromWIF('cQqjeq2rxqwnqwMewJhkNtJDixtX8ctA4bYoWHdxY4xRPVvAEjmk', kpNetwork)
+var kpAddress = keyPair.getAddress()
+var conflicts = {}
+
+function fundAddress (unspents, outputs, callback) {
+  // avoid too-long-mempool-chain
+  unspents = unspents.filter(function (x) {
+    return x.confirmations > 0 && !conflicts[x.txId + x.vout]
+  })
+
+  var result = coinSelect(unspents, outputs, 10)
+  if (!result.inputs) return callback(new Error('Faucet empty'))
+
+  var txb = new bitcoin.TransactionBuilder(kpNetwork)
+  result.inputs.forEach(function (x) {
+    conflicts[x.txId + x.vout] = true
+    txb.addInput(x.txId, x.vout)
+  })
+
+  result.outputs.forEach(function (x) {
+    if (x.address) console.warn('funding ' + x.address + ' w/ ' + x.value)
+    txb.addOutput(x.address || kpAddress, x.value)
+  })
+
+  result.inputs.forEach(function (_, i) {
+    txb.sign(i, keyPair)
+  })
+
+  var tx = txb.build()
+
+  blockchain.transactions.propagate(tx.toHex(), function (err) {
+    if (err) return callback(err)
+
+    var txId = tx.getId()
+    callback(null, outputs.map(function (x, i) {
+      return { txId: txId, vout: i, value: x.value }
+    }))
+  })
+}
+
+blockchain.faucetMany = function faucetMany (outputs, callback) {
+  blockchain.addresses.unspents(kpAddress, function (err, unspents) {
+    if (err) return callback(err)
+
+    typeforce([{
+      txId: types.Hex,
+      vout: types.UInt32,
+      value: types.Satoshi
+    }], unspents)
+
+    fundAddress(unspents, outputs, callback)
+  })
+}
+
+blockchain.faucet = function faucet (address, value, callback) {
+  blockchain.faucetMany([{ address: address, value: value }], function (err, unspents) {
+    callback(err, unspents && unspents[0])
+  })
+}
+
+// verify TX was accepted
+blockchain.verify = function verify (address, txId, value, done) {
+  async.retry(5, function (callback) {
+    setTimeout(function () {
+      // check that the above transaction included the intended address
+      dhttp({
+        method: 'POST',
+        url: 'https://api.ei8ht.com.au:9443/3/txs',
+        body: [txId]
+      }, function (err, result) {
+        if (err) return callback(err)
+        if (!result[txId]) return callback(new Error('Could not find ' + txId))
+        callback()
+      })
+    }, 400)
+  }, done)
+}
+
+blockchain.transactions.propagate = function broadcast (txHex, callback) {
+  dhttp({
+    method: 'POST',
+    url: 'https://api.ei8ht.com.au:9443/3/pushtx',
+    body: txHex
+  }, callback)
+}
+
+blockchain.RETURN_ADDRESS = kpAddress
+module.exports = blockchain

--- a/test/integration/addresses.js
+++ b/test/integration/addresses.js
@@ -1,0 +1,140 @@
+/* global describe, it */
+
+var assert = require('assert')
+var bigi = require('bigi')
+var bitcoin = require('../../')
+var dhttp = require('dhttp/200')
+
+// deterministic RNG for testing only
+function rng () { return Buffer.from('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
+
+describe('bitcoinjs-lib (addresses)', function () {
+  it('can generate a random address', function () {
+    var keyPair = bitcoin.ECPair.makeRandom({ rng: rng })
+    var address = keyPair.getAddress()
+
+    assert.strictEqual(address, '1F5VhMHukdnUES9kfXqzPzMeF1GPHKiF64')
+  })
+
+  it('can generate an address from a SHA256 hash', function () {
+    var hash = bitcoin.crypto.sha256('correct horse battery staple')
+    var d = bigi.fromBuffer(hash)
+
+    var keyPair = new bitcoin.ECPair(d)
+    var address = keyPair.getAddress()
+
+    assert.strictEqual(address, '1C7zdTfnkzmr13HfA2vNm5SJYRK6nEKyq8')
+  })
+
+  it('can import an address via WIF', function () {
+    var keyPair = bitcoin.ECPair.fromWIF('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct')
+    var address = keyPair.getAddress()
+
+    assert.strictEqual(address, '19AAjaTUbRjQCMuVczepkoPswiZRhjtg31')
+  })
+
+  it('can generate a 2-of-3 multisig P2SH address', function () {
+    var pubKeys = [
+      '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
+      '02c96db2302d19b43d4c69368babace7854cc84eb9e061cde51cfa77ca4a22b8b9',
+      '03c6103b3b83e4a24a0e33a4df246ef11772f9992663db0c35759a5e2ebf68d8e9'
+    ].map(function (hex) { return Buffer.from(hex, 'hex') })
+
+    var redeemScript = bitcoin.script.multisig.output.encode(2, pubKeys) // 2 of 3
+    var scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript))
+    var address = bitcoin.address.fromOutputScript(scriptPubKey)
+
+    assert.strictEqual(address, '36NUkt6FWUi3LAWBqWRdDmdTWbt91Yvfu7')
+  })
+
+  it('can generate a SegWit address', function () {
+    var keyPair = bitcoin.ECPair.fromWIF('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct')
+    var pubKey = keyPair.getPublicKeyBuffer()
+
+    var scriptPubKey = bitcoin.script.witnessPubKeyHash.output.encode(bitcoin.crypto.hash160(pubKey))
+    var address = bitcoin.address.fromOutputScript(scriptPubKey)
+
+    assert.strictEqual(address, 'bc1qt97wqg464zrhnx23upykca5annqvwkwujjglky')
+  })
+
+  it('can generate a SegWit address (via P2SH)', function () {
+    var keyPair = bitcoin.ECPair.fromWIF('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct')
+    var pubKey = keyPair.getPublicKeyBuffer()
+
+    var witnessScript = bitcoin.script.witnessPubKeyHash.output.encode(bitcoin.crypto.hash160(pubKey))
+    var scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(witnessScript))
+    var address = bitcoin.address.fromOutputScript(scriptPubKey)
+
+    assert.strictEqual(address, '34AgLJhwXrvmkZS1o5TrcdeevMt22Nar53')
+  })
+
+  it('can generate a SegWit 3-of-4 multisig address', function () {
+    var pubKeys = [
+      '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
+      '02c96db2302d19b43d4c69368babace7854cc84eb9e061cde51cfa77ca4a22b8b9',
+      '023e4740d0ba639e28963f3476157b7cf2fb7c6fdf4254f97099cf8670b505ea59',
+      '03c6103b3b83e4a24a0e33a4df246ef11772f9992663db0c35759a5e2ebf68d8e9'
+    ].map(function (hex) { return Buffer.from(hex, 'hex') })
+
+    var witnessScript = bitcoin.script.multisig.output.encode(3, pubKeys) // 3 of 4
+    var scriptPubKey = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(witnessScript))
+    var address = bitcoin.address.fromOutputScript(scriptPubKey)
+
+    assert.strictEqual(address, 'bc1q75f6dv4q8ug7zhujrsp5t0hzf33lllnr3fe7e2pra3v24mzl8rrqtp3qul')
+  })
+
+  it('can generate a SegWit 2-of-2 multisig address (via P2SH)', function () {
+    var pubKeys = [
+      '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
+      '02c96db2302d19b43d4c69368babace7854cc84eb9e061cde51cfa77ca4a22b8b9'
+    ].map(function (hex) { return Buffer.from(hex, 'hex') })
+
+    var witnessScript = bitcoin.script.multisig.output.encode(2, pubKeys) // 2 of 2
+    var redeemScript = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(witnessScript))
+    var scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript))
+    var address = bitcoin.address.fromOutputScript(scriptPubKey)
+
+    assert.strictEqual(address, '3P4mrxQfmExfhxqjLnR2Ah4WES5EB1KBrN')
+  })
+
+  it('can support the retrieval of transactions for an address (3rd party blockchain)', function (done) {
+    var keyPair = bitcoin.ECPair.makeRandom()
+    var address = keyPair.getAddress()
+
+    dhttp({
+      method: 'POST',
+      url: 'https://api.ei8ht.com.au/3/addrtxs',
+      body: {
+        addrs: [address],
+        height: 0
+      }
+    }, function (err, transactions) {
+      if (err) return done(err)
+
+      // random private keys [probably] have no transactions
+      assert.strictEqual(Object.keys(transactions).length, 0)
+      done()
+    })
+  })
+
+  // other networks
+  it('can generate a Testnet address', function () {
+    var testnet = bitcoin.networks.testnet
+    var keyPair = bitcoin.ECPair.makeRandom({ network: testnet, rng: rng })
+    var wif = keyPair.toWIF()
+    var address = keyPair.getAddress()
+
+    assert.strictEqual(address, 'mubSzQNtZfDj1YdNP6pNDuZy6zs6GDn61L')
+    assert.strictEqual(wif, 'cRgnQe9MUu1JznntrLaoQpB476M8PURvXVQB5R2eqms5tXnzNsrr')
+  })
+
+  it('can generate a Litecoin address', function () {
+    var litecoin = bitcoin.networks.litecoin
+    var keyPair = bitcoin.ECPair.makeRandom({ network: litecoin, rng: rng })
+    var wif = keyPair.toWIF()
+    var address = keyPair.getAddress()
+
+    assert.strictEqual(address, 'LZJSxZbjqJ2XVEquqfqHg1RQTDdfST5PTn')
+    assert.strictEqual(wif, 'T7A4PUSgTDHecBxW1ZiYFrDNRih2o7M8Gf9xpoCgudPF9gDiNvuS')
+  })
+})

--- a/test/integration/transactions.js
+++ b/test/integration/transactions.js
@@ -1,0 +1,219 @@
+/* global describe, it */
+
+var assert = require('assert')
+var bitcoin = require('../../')
+var dhttp = require('dhttp/200')
+var testnet = bitcoin.networks.testnet
+var testnetUtils = require('./_testnet')
+
+function rng () {
+  return Buffer.from('YT8dAtK4d16A3P1z+TpwB2jJ4aFH3g9M1EioIBkLEV4=', 'base64')
+}
+
+describe('bitcoinjs-lib (transactions)', function () {
+  it('can create a 1-to-1 Transaction', function () {
+    var alice = bitcoin.ECPair.fromWIF('L1uyy5qTuGrVXrmrsvHWHgVzW9kKdrp27wBC7Vs6nZDTF2BRUVwy')
+    var txb = new bitcoin.TransactionBuilder()
+
+    txb.addInput('61d520ccb74288c96bc1a2b20ea1c0d5a704776dd0164a396efec3ea7040349d', 0) // Alice's previous transaction output, has 15000 satoshis
+    txb.addOutput('1cMh228HTCiwS8ZsaakH8A8wze1JR5ZsP', 12000)
+    // (in)15000 - (out)12000 = (fee)3000, this is the miner fee
+
+    txb.sign(0, alice)
+
+    // prepare for broadcast to the Bitcoin network, see "can broadcast a Transaction" below
+    assert.strictEqual(txb.build().toHex(), '01000000019d344070eac3fe6e394a16d06d7704a7d5c0a10eb2a2c16bc98842b7cc20d561000000006b48304502210088828c0bdfcdca68d8ae0caeb6ec62cd3fd5f9b2191848edae33feb533df35d302202e0beadd35e17e7f83a733f5277028a9b453d525553e3f5d2d7a7aa8010a81d60121029f50f51d63b345039a290c94bffd3180c99ed659ff6ea6b1242bca47eb93b59fffffffff01e02e0000000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac00000000')
+  })
+
+  it('can create a 2-to-2 Transaction', function () {
+    var alice = bitcoin.ECPair.fromWIF('L1Knwj9W3qK3qMKdTvmg3VfzUs3ij2LETTFhxza9LfD5dngnoLG1')
+    var bob = bitcoin.ECPair.fromWIF('KwcN2pT3wnRAurhy7qMczzbkpY5nXMW2ubh696UBc1bcwctTx26z')
+
+    var txb = new bitcoin.TransactionBuilder()
+    txb.addInput('b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c', 6) // Alice's previous transaction output, has 200000 satoshis
+    txb.addInput('7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730', 0) // Bob's previous transaction output, has 300000 satoshis
+    txb.addOutput('1CUNEBjYrCn2y1SdiUMohaKUi4wpP326Lb', 180000)
+    txb.addOutput('1JtK9CQw1syfWj1WtFMWomrYdV3W2tWBF9', 170000)
+    // (in)(200000 + 300000) - (out)(180000 + 150000) = (fee)170000, this is the miner fee
+
+    txb.sign(1, bob) // Bob signs his input, which was the second input (1th)
+    txb.sign(0, alice) // Alice signs her input, which was the first input (0th)
+
+    // prepare for broadcast to the Bitcoin network, see "can broadcast a Transaction" below
+    assert.strictEqual(txb.build().toHex(), '01000000024c94e48a870b85f41228d33cf25213dfcc8dd796e7211ed6b1f9a014809dbbb5060000006a473044022041450c258ce7cac7da97316bf2ea1ce66d88967c4df94f3e91f4c2a30f5d08cb02203674d516e6bb2b0afd084c3551614bd9cec3c2945231245e891b145f2d6951f0012103e05ce435e462ec503143305feb6c00e06a3ad52fbf939e85c65f3a765bb7baacffffffff3077d9de049574c3af9bc9c09a7c9db80f2d94caaf63988c9166249b955e867d000000006b483045022100aeb5f1332c79c446d3f906e4499b2e678500580a3f90329edf1ba502eec9402e022072c8b863f8c8d6c26f4c691ac9a6610aa4200edc697306648ee844cfbc089d7a012103df7940ee7cddd2f97763f67e1fb13488da3fbdd7f9c68ec5ef0864074745a289ffffffff0220bf0200000000001976a9147dd65592d0ab2fe0d0257d571abf032cd9db93dc88ac10980200000000001976a914c42e7ef92fdb603af844d064faad95db9bcdfd3d88ac00000000')
+  })
+
+  it('can create (and broadcast via 3PBP) a typical Transaction', function (done) {
+    this.timeout(30000)
+
+    var alice1 = bitcoin.ECPair.makeRandom({ network: testnet })
+    var alice2 = bitcoin.ECPair.makeRandom({ network: testnet })
+    var aliceChange = bitcoin.ECPair.makeRandom({ rng: rng, network: testnet })
+
+    // "simulate" on testnet that Alice has 2 unspent outputs
+    testnetUtils.faucetMany([
+      {
+        address: alice1.getAddress(),
+        value: 5e4
+      },
+      {
+        address: alice2.getAddress(),
+        value: 7e4
+      }
+    ], function (err, unspents) {
+      if (err) return done(err)
+
+      var txb = new bitcoin.TransactionBuilder(testnet)
+      txb.addInput(unspents[0].txId, unspents[0].vout) // alice1 unspent
+      txb.addInput(unspents[1].txId, unspents[1].vout) // alice2 unspent
+      txb.addOutput('mwCwTceJvYV27KXBc3NJZys6CjsgsoeHmf', 8e4) // the actual "spend"
+      txb.addOutput(aliceChange.getAddress(), 1e4) // Alice's change
+      // (in)(4e4 + 2e4) - (out)(1e4 + 3e4) = (fee)2e4 = 20000, this is the miner fee
+
+      // Alice signs each input with the respective private keys
+      txb.sign(0, alice1)
+      txb.sign(1, alice2)
+
+      // build and broadcast to the Bitcoin Testnet network
+      dhttp({
+        method: 'POST',
+        url: 'https://api.ei8ht.com.au:9443/3/pushtx',
+//          url: 'http://tbtc.blockr.io/api/v1/tx/push',
+        body: txb.build().toHex()
+      }, done)
+      // to build and broadcast to the actual Bitcoin network, see https://github.com/bitcoinjs/bitcoinjs-lib/issues/839
+    })
+  })
+
+  it('can create (and broadcast via 3PBP) a Transaction with an OP_RETURN output', function (done) {
+    this.timeout(30000)
+
+    var keyPair = bitcoin.ECPair.makeRandom({ network: testnet })
+    var address = keyPair.getAddress()
+
+    testnetUtils.faucet(address, 5e4, function (err, unspent) {
+      if (err) return done(err)
+
+      var txb = new bitcoin.TransactionBuilder(testnet)
+      var data = Buffer.from('bitcoinjs-lib', 'utf8')
+      var dataScript = bitcoin.script.nullData.output.encode(data)
+
+      txb.addInput(unspent.txId, unspent.vout)
+      txb.addOutput(dataScript, 1000)
+      txb.addOutput(testnetUtils.RETURN_ADDRESS, 4e4)
+      txb.sign(0, keyPair)
+
+      // build and broadcast to the Bitcoin Testnet network
+      dhttp({
+        method: 'POST',
+        url: 'https://api.ei8ht.com.au:9443/3/pushtx',
+        body: txb.build().toHex()
+      }, done)
+    })
+  })
+
+  it('can create (and broadcast via 3PBP) a Transaction with a 2-of-4 P2SH(multisig) input', function (done) {
+    this.timeout(30000)
+
+    var keyPairs = [
+      '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+      '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
+      '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx3cTMqe',
+      '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx9rcrL7'
+    ].map(function (wif) { return bitcoin.ECPair.fromWIF(wif, testnet) })
+    var pubKeys = keyPairs.map(function (x) { return x.getPublicKeyBuffer() })
+
+    var redeemScript = bitcoin.script.multisig.output.encode(2, pubKeys)
+    var scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript))
+    var address = bitcoin.address.fromOutputScript(scriptPubKey, testnet)
+
+    testnetUtils.faucet(address, 2e4, function (err, unspent) {
+      if (err) return done(err)
+
+      var txb = new bitcoin.TransactionBuilder(testnet)
+      txb.addInput(unspent.txId, unspent.vout)
+      txb.addOutput(testnetUtils.RETURN_ADDRESS, 1e4)
+
+      txb.sign(0, keyPairs[0], redeemScript)
+      txb.sign(0, keyPairs[2], redeemScript)
+
+      var tx = txb.build()
+
+      // build and broadcast to the Bitcoin Testnet network
+      testnetUtils.transactions.propagate(tx.toHex(), function (err) {
+        if (err) return done(err)
+
+        testnetUtils.verify(address, tx.getId(), 1e4, done)
+      })
+    })
+  })
+
+  it('can create (and broadcast via 3PBP) a Transaction with a SegWit P2SH(P2WPKH) input', function (done) {
+    this.timeout(30000)
+
+    var keyPair = bitcoin.ECPair.fromWIF('cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA', testnet)
+    var pubKey = keyPair.getPublicKeyBuffer()
+    var pubKeyHash = bitcoin.crypto.hash160(pubKey)
+
+    var redeemScript = bitcoin.script.witnessPubKeyHash.output.encode(pubKeyHash)
+    var redeemScriptHash = bitcoin.crypto.hash160(redeemScript)
+
+    var scriptPubKey = bitcoin.script.scriptHash.output.encode(redeemScriptHash)
+    var address = bitcoin.address.fromOutputScript(scriptPubKey, testnet)
+
+    testnetUtils.faucet(address, 5e4, function (err, unspent) {
+      if (err) return done(err)
+
+      var txb = new bitcoin.TransactionBuilder(testnet)
+      txb.addInput(unspent.txId, unspent.vout)
+      txb.addOutput(testnetUtils.RETURN_ADDRESS, 4e4)
+      txb.sign(0, keyPair, redeemScript, null, unspent.value)
+
+      var tx = txb.build()
+
+      // build and broadcast to the Bitcoin Testnet network
+      testnetUtils.transactions.propagate(tx.toHex(), function (err) {
+        if (err) return done(err)
+
+        testnetUtils.verify(address, tx.getId(), 1e4, done)
+      })
+    })
+  })
+
+  it('can create (and broadcast via 3PBP) a Transaction with a SegWit 3-of-4 P2SH(P2WSH(multisig)) input', function (done) {
+    this.timeout(50000)
+
+    var keyPairs = [
+      'cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87JcbXMTcA',
+      'cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87K7XCyj5v',
+      'cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87KcLPVfXz',
+      'cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87L7FgDCKE'
+    ].map(function (wif) { return bitcoin.ECPair.fromWIF(wif, testnet) })
+    var pubKeys = keyPairs.map(function (x) { return x.getPublicKeyBuffer() })
+
+    var witnessScript = bitcoin.script.multisig.output.encode(3, pubKeys)
+    var redeemScript = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(witnessScript))
+    var scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript))
+    var address = bitcoin.address.fromOutputScript(scriptPubKey, testnet)
+
+    testnetUtils.faucet(address, 6e4, function (err, unspent) {
+      if (err) return done(err)
+
+      var txb = new bitcoin.TransactionBuilder(testnet)
+      txb.addInput(unspent.txId, unspent.vout)
+      txb.addOutput(testnetUtils.RETURN_ADDRESS, 4e4)
+      txb.sign(0, keyPairs[0], redeemScript, null, unspent.value, witnessScript)
+      txb.sign(0, keyPairs[2], redeemScript, null, unspent.value, witnessScript)
+      txb.sign(0, keyPairs[3], redeemScript, null, unspent.value, witnessScript)
+
+      var tx = txb.build()
+
+      // build and broadcast to the Bitcoin Testnet network
+      testnetUtils.transactions.propagate(tx.toHex(), function (err) {
+        if (err) return done(err)
+
+        testnetUtils.verify(address, tx.getId(), 4e4, done)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR brings with it support for bitcoin-cash and bitcoin gold.

I pulled the https://github.com/dabura667/bitcoinjs-lib/tree/forks331/ branch in locally and merged it with `master`. I was thinking we just use the `forks331` as our main codebase and publish that, but BitGo devs have made commits to the master branch in the past so we want to preserve those.

If there are future hardforks that require additional bitcoinjs-lib signing logic, we can either write them ourselves and merge them into our `master` branch, or if someone like dabura667 writes the logic for us we can update our local `forks331` branch from upstream and merge that into `master`.