### PR TITLE
feat: support deriving p2tr output from address

### DIFF
--- a/test/fixtures/p2tr.json
+++ b/test/fixtures/p2tr.json
@@ -64,6 +64,18 @@
         "name": "p2tr",
         "address": "tb1p6h5fuzmnvpdthf5shf0qqjzwy7wsqc5rhmgq2ks9xrak4ry6mtrscsqvzp"
       }
+    },
+    {
+      "description": "p2tr, output from address",
+      "arguments": {
+        "address": "bcrt1pvxx5zs9mlxqfw6s0f5hlnwc95emjse5yqacy2tl5q52ghpe0phyqzwzvwu",
+        "network": "regtest"
+      },
+      "options": {},
+      "expected": {
+        "name": "p2tr",
+        "output": "OP_1 618d4140bbf980976a0f4d2ff9bb05a6772866840770452ff405148b872f0dc8"
+      }
     }
   ],
   "invalid": []


### PR DESCRIPTION
This commit allows for deriving p2tr output scripts from bech32m addresses using the p2tr payment builder.

This will be helpful for adding p2tr tests to utxo-lib.

Ticket: BG-35573