### PR TITLE
feat: p2tr script path classification & validation

### DIFF
--- a/src/payments/p2tr.js
+++ b/src/payments/p2tr.js
@@ -49,11 +49,13 @@ function p2tr(a, opts) {
           witness: typef.maybe(typef.arrayOf(typef.Buffer)),
         }),
       ),
-      redeemIndex: typef.maybe(typef.Number), // Selects the redeem to spend
+      redeemIndex: typef.maybe(typef.Number),
+      witness: typef.maybe(typef.arrayOf(typef.Buffer)),
     },
     a,
   );
   const _address = lazy.value(() => {
+    if (!a.address) return undefined;
     const result = bech32m.decode(a.address);
     const version = result.words.shift();
     const data = bech32m.fromWords(result.words);
@@ -96,6 +98,13 @@ function p2tr(a, opts) {
     }
   });
   const _taprootPubkey = lazy.value(() => {
+    // this should be `a.output || _address()?.data` but prettier doesn't recognize ? operator
+    const output = a.output || (a.address ? _address().data : undefined);
+    if (output) {
+      // we remove the first two bytes (OP_1 0x20) from the output script to
+      // extract the 32 byte taproot pubkey (aka witness program)
+      return { pubkey: output.slice(2), parity: 0 };
+    }
     const internalPubkey = _internalPubkey();
     if (!internalPubkey) return;
     const taptree = _taptree();
@@ -107,10 +116,9 @@ function p2tr(a, opts) {
   const network = a.network || networks_1.bitcoin;
   const o = { network };
   lazy.prop(o, 'address', () => {
-    if (!o.output) return;
-    // we remove the first two bytes (OP_1 0x20) from the output script to
+    if (!a.output && !o.output) return;
     // only encode the 32 byte witness program as bech32m
-    const words = bech32m.toWords(o.output.slice(2));
+    const words = bech32m.toWords(_taprootPubkey().pubkey);
     words.unshift(0x01);
     return bech32m.encode(network.bech32, words);
   });
@@ -163,12 +171,43 @@ function p2tr(a, opts) {
     const nameParts = ['p2tr'];
     return nameParts.join('-');
   });
+  lazy.prop(o, 'redeem', () => {
+    if (!a.redeems || a.redeemIndex === undefined) return;
+    return a.redeems[a.redeemIndex];
+  });
   // extended validation
   if (opts.validate) {
     // TODO: complete extended validation
     if (a.output) {
       if (a.output[0] !== OPS.OP_1 || a.output[1] !== 0x20)
         throw new TypeError('Output is invalid');
+      if (a.address) {
+        // if we're passed both an output script and an address, ensure they match
+        if (Buffer.compare(_address().data, _taprootPubkey().pubkey) !== 0) {
+          throw new TypeError('mismatch between address & output');
+        }
+      }
+    }
+    if (a.witness) {
+      const witnessStack = taproot.removeAnnex(a.witness);
+      if (witnessStack.length === 0) {
+        throw new TypeError('witness stack cannot be empty');
+      } else if (witnessStack.length === 1) {
+        // if there's only a single element it should be a key path spend schnorr signature
+        if (!bscript.isCanonicalSchnorrSignature(witnessStack[0])) {
+          throw new TypeError(
+            'a single witness stack element must be a schnorr signature',
+          );
+        }
+      } else if (a.output) {
+        // more than one element indicates a script path spend, ensure that our witness stack
+        // contains a script that is included in our taproot pub key
+        if (!taproot.isValidTapscript(witnessStack, _taprootPubkey().pubkey)) {
+          throw new TypeError(
+            'tapscript & control block does not match witness program ',
+          );
+        }
+      }
     }
     if (a.redeems) {
       a.redeems.forEach(redeem => {

--- a/src/taproot.js
+++ b/src/taproot.js
@@ -3,10 +3,11 @@
 // https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
 Object.defineProperty(exports, '__esModule', { value: true });
-exports.getControlBlock = exports.getHuffmanTaptree = exports.tapTweakPubkey = exports.hashTapBranch = exports.hashTapLeaf = exports.serializeScriptSize = exports.aggregateMuSigPubkeys = exports.EVEN_Y_COORD_PREFIX = void 0;
+exports.isScriptPathSpend = exports.isValidTapscript = exports.removeAnnex = exports.getControlBlock = exports.getHuffmanTaptree = exports.tapTweakPubkey = exports.hashTapBranch = exports.hashTapLeaf = exports.serializeScriptSize = exports.aggregateMuSigPubkeys = exports.EVEN_Y_COORD_PREFIX = void 0;
 const assert = require('assert');
 const FastPriorityQueue = require('fastpriorityqueue');
 const bcrypto = require('./crypto');
+const bscript = require('./script');
 const varuint = require('varuint-bitcoin');
 const ecc = require('tiny-secp256k1');
 /**
@@ -44,8 +45,7 @@ function aggregateMuSigPubkeys(pubkeys) {
     pubkeys.length > 1,
     'at least two pubkeys are required for musig key aggregation',
   );
-  // Trim the 0x02/0x03 leading byte from each key and sort in ascending order
-  // to convert to 32 byte x-coordinates with implicit even Y coordinates.
+  // Sort the keys in ascending order
   pubkeys.sort(Buffer.compare);
   // In MuSig all signers contribute key material to a single signing key,
   // using the equation
@@ -214,3 +214,146 @@ function getControlBlock(parity, pubkey, path) {
   return Buffer.concat([new Uint8Array([parityVersion]), pubkey, ...path]);
 }
 exports.getControlBlock = getControlBlock;
+/**
+ * Identifies and removes the annex from a taproot witness stack if the annex is present.
+ * @param witnessStack
+ * @returns the witness stack without an annex
+ */
+function removeAnnex(witnessStack) {
+  if (
+    witnessStack.length >= 2 &&
+    witnessStack[witnessStack.length - 1][0] === 0x50
+  ) {
+    // If there are at least two witness elements, and the first byte of the last element is
+    // 0x50, this last element is called annex a and is removed from the witness stack
+    return witnessStack.slice(0, witnessStack.length - 1);
+  }
+  return witnessStack;
+}
+exports.removeAnnex = removeAnnex;
+/**
+ * Parses a taproot witness stack and extracts key data elements.
+ * @param witnessStack
+ * @returns an object containing the tapscript, control block, taptree depth, internal pubkey, and leaf version
+ * @throws if the witness stack does not conform to the BIP 341 script validation rules
+ */
+function parseTaprootWitness(witnessStack) {
+  if (witnessStack.length < 2) {
+    throw new Error('witness stack must have at least two elements');
+  }
+  // second to last element is the tapscript
+  const tapscript = witnessStack[witnessStack.length - 2];
+  const tapscriptChunks = bscript.decompile(tapscript);
+  if (!tapscriptChunks || tapscriptChunks.length === 0) {
+    throw new Error('tapscript is not a valid script');
+  }
+  // The last stack element is called the control block c, and must have length 33 + 32m,
+  // for a value of m that is an integer between 0 and 128, inclusive
+  const controlBlock = witnessStack[witnessStack.length - 1];
+  if (
+    controlBlock.length < 33 ||
+    controlBlock.length > 33 + 32 * 128 ||
+    controlBlock.length % 32 !== 1
+  ) {
+    throw new Error('invalid control block length');
+  }
+  const taptreeDepth = Math.floor(controlBlock.length / 32) - 1;
+  const parity = controlBlock[0] & 0x01;
+  // Let p = c[1:33] and let P = lift_x(int(p)) where lift_x and [:] are defined as in BIP340.
+  // Fail if this point is not on the curve
+  const internalPubkey = controlBlock.slice(1, 33);
+  if (
+    !ecc.isPoint(Buffer.concat([exports.EVEN_Y_COORD_PREFIX, internalPubkey]))
+  ) {
+    throw new Error('internal pubkey is not an EC point');
+  }
+  // The leaf version cannot be 0x50 as that would result in ambiguity with the annex.
+  const leafVersion = controlBlock[0] & 0xfe;
+  if (leafVersion === 0x50) {
+    throw new Error('invalid leaf version');
+  }
+  return {
+    tapscript,
+    controlBlock,
+    taptreeDepth,
+    parity,
+    internalPubkey,
+    leafVersion,
+  };
+}
+/**
+ * Checks whether the tapscript and control block from a witness stack matches a 32 byte witness
+ * program (aka taproot pubkey) by validating the merkle proof for its inclusion in the taptree.
+ * @param witnessStack a stack of witness elements containing the tapscript and control block
+ * @param expectedTaprootPubkey the 32-byte array containing the witness program (the second
+ * push in the scriptPubKey) which represents a public key according to BIP340 and which we
+ * expect to match the taproot pubkey derived from the control block
+ * @returns `true` if the tapscript matches the witness program, otherwise `false`
+ * @throws if the witness stack does not conform to the BIP 341 script validation rules
+ */
+function isValidTapscript(witnessStack, expectedTaprootPubkey) {
+  const {
+    tapscript,
+    controlBlock,
+    taptreeDepth,
+    parity,
+    internalPubkey,
+    leafVersion,
+  } = parseTaprootWitness(witnessStack);
+  const tapleafHash = taggedHash(
+    'TapLeaf',
+    Buffer.concat([
+      new Uint8Array([leafVersion]),
+      serializeScriptSize(tapscript),
+      tapscript,
+    ]),
+  );
+  // `taptreeMerkleHash` begins as our tapscript tapleaf hash and its value iterates
+  // through its parent tapbranch hashes until it ends up as the taptree root hash
+  let taptreeMerkleHash = tapleafHash;
+  for (let j = 0; j < taptreeDepth; j += 1) {
+    const taptreeSiblingHash = controlBlock.slice(33 + 32 * j, 65 + 32 * j);
+    taptreeMerkleHash =
+      Buffer.compare(taptreeMerkleHash, taptreeSiblingHash) === -1
+        ? taggedHash(
+            'TapBranch',
+            Buffer.concat([taptreeMerkleHash, taptreeSiblingHash]),
+          )
+        : taggedHash(
+            'TapBranch',
+            Buffer.concat([taptreeSiblingHash, taptreeMerkleHash]),
+          );
+  }
+  const tapTweak = taggedHash(
+    'TapTweak',
+    Buffer.concat([internalPubkey, taptreeMerkleHash]),
+  );
+  // If t ≥ order of secp256k1, pointAddScalar call below will throw.
+  const taprootPubkey = ecc.pointAddScalar(
+    Buffer.concat([exports.EVEN_Y_COORD_PREFIX, internalPubkey]),
+    tapTweak,
+  );
+  const taprootPubkeyParity =
+    taprootPubkey[0] === exports.EVEN_Y_COORD_PREFIX[0] ? 0 : 1;
+  return (
+    Buffer.compare(expectedTaprootPubkey, taprootPubkey.slice(1)) === 0 &&
+    parity === taprootPubkeyParity
+  );
+}
+exports.isValidTapscript = isValidTapscript;
+/**
+ * Checks whether an array of buffers can be parsed according to the BIP 341 script validation rules
+ * @param chunks
+ * @returns `true` if `chunks` can be parsed according to the BIP 341 script validation rules, otherwise `false`
+ */
+function isScriptPathSpend(chunks) {
+  // check whether parsing the witness as a taproot witness fails
+  // this indicates whether `chunks` is the witness stack for a taproot script path spend
+  try {
+    parseTaprootWitness(chunks);
+    return true;
+  } catch (_a) {
+    return false;
+  }
+}
+exports.isScriptPathSpend = isScriptPathSpend;

--- a/src/templates/taproot/input.js
+++ b/src/templates/taproot/input.js
@@ -1,11 +1,22 @@
 'use strict';
-// {signature}
-// TODO: define p2tr script path input template
+// key path spend - {signature}
+// script path spend - [...stack elements] {tapscript} {control block}
+// https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.check = void 0;
 const bscript = require('../../script');
+const taproot = require('../../taproot');
 function check(chunks) {
-  return chunks.length === 1 && bscript.isCanonicalSchnorrSignature(chunks[0]);
+  chunks = taproot.removeAnnex(chunks);
+  if (chunks.length === 0) {
+    return false;
+  } else if (chunks.length === 1) {
+    // possible key path spend
+    return bscript.isCanonicalSchnorrSignature(chunks[0]);
+  } else {
+    // possible script path spend
+    return taproot.isScriptPathSpend(chunks);
+  }
 }
 exports.check = check;
 check.toJSON = () => {

--- a/test/fixtures/p2tr.json
+++ b/test/fixtures/p2tr.json
@@ -141,7 +141,52 @@
         "name": "p2tr",
         "output": "OP_1 618d4140bbf980976a0f4d2ff9bb05a6772866840770452ff405148b872f0dc8"
       }
+    },
+    {
+      "description": "p2tr OP_CHECKSIG script path spend",
+      "arguments": {
+        "witness": [
+          "e6e81bea57db6bed922afbc5fab65c61f546b6f467b8c3570b5478ba21851e57b00bef791cd06d58afebb883770d956afaf2a9a796fb594a85d124b6837a4c7101",
+          "20dcd9a3fdad900e39ff367823f5d683135238d04425ac8dce19d0220e5791c700ac",
+          "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+        ],
+        "output": "OP_1 3d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+        "network": "testnet"
+      },
+      "options": {},
+      "expected": {
+        "name": "p2tr"
+      }
     }
   ],
-  "invalid": []
+  "invalid": [
+    {
+      "description": "p2tr OP_CHECKSIG script path spend with script missing from tap tree",
+      "arguments": {
+        "witness": [
+          "e6e81bea57db6bed922afbc5fab65c61f546b6f467b8c3570b5478ba21851e57b00bef791cd06d58afebb883770d956afaf2a9a796fb594a85d124b6837a4c7101",
+          "204d4b27ab455a6e2b03af29a141ef47fc579c8435f563c065bf0dd12e6180ccd4ac",
+          "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+        ],
+        "output": "OP_1 3d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+        "network": "testnet"
+      },
+      "options": {},
+      "expected": {
+        "name": "p2tr"
+      }
+    },
+    {
+      "description": "p2tr, testnet address with mismatched output",
+      "arguments": {
+        "address": "tb1p6h5fuzmnvpdthf5shf0qqjzwy7wsqc5rhmgq2ks9xrak4ry6mtrscsqvzp",
+        "output": "OP_1 618d4140bbf980976a0f4d2ff9bb05a6772866840770452ff405148b872f0dc8",
+        "network": "testnet"
+      },
+      "options": {},
+      "expected": {
+        "name": "p2tr"
+      }
+    }
+  ]
 }

--- a/test/fixtures/templates.json
+++ b/test/fixtures/templates.json
@@ -128,6 +128,16 @@
       "outputHex": "5120d8f4f1d18996db61bb1caf5423de25d8a1eee9c950d37e6ffa023012d5e62e0d"
     },
     {
+      "type": "taproot",
+      "witnessData": [
+        "e6e81bea57db6bed922afbc5fab65c61f546b6f467b8c3570b5478ba21851e57b00bef791cd06d58afebb883770d956afaf2a9a796fb594a85d124b6837a4c7101",
+        "20dcd9a3fdad900e39ff367823f5d683135238d04425ac8dce19d0220e5791c700ac",
+        "c150929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+      ],
+      "output": "OP_1 3d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6",
+      "outputHex": "51203d3e6d002d642acf8653bcf26b81dbe656df5bf88b6d54221b2606bc78f3d4e6"
+    },
+    {
       "type": "nulldata",
       "data": [
         "06deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474"

--- a/ts_src/templates/taproot/input.ts
+++ b/ts_src/templates/taproot/input.ts
@@ -1,10 +1,22 @@
-// {signature}
-// TODO: define p2tr script path input template
+// key path spend - {signature}
+// script path spend - [...stack elements] {tapscript} {control block}
+// https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
 
 import * as bscript from '../../script';
+import * as taproot from '../../taproot';
 
 export function check(chunks: Buffer[]): boolean {
-  return chunks.length === 1 && bscript.isCanonicalSchnorrSignature(chunks[0]);
+  chunks = taproot.removeAnnex(chunks);
+
+  if (chunks.length === 0) {
+    return false;
+  } else if (chunks.length === 1) {
+    // possible key path spend
+    return bscript.isCanonicalSchnorrSignature(chunks[0]);
+  } else {
+    // possible script path spend
+    return taproot.isScriptPathSpend(chunks);
+  }
 }
 check.toJSON = (): string => {
   return 'taproot input';

--- a/types/taproot.d.ts
+++ b/types/taproot.d.ts
@@ -55,3 +55,26 @@ export interface Taptree {
  */
 export declare function getHuffmanTaptree(scripts: Buffer[], weights: Array<number | undefined>): Taptree;
 export declare function getControlBlock(parity: 0 | 1, pubkey: Buffer, path: Buffer[]): Buffer;
+/**
+ * Identifies and removes the annex from a taproot witness stack if the annex is present.
+ * @param witnessStack
+ * @returns the witness stack without an annex
+ */
+export declare function removeAnnex(witnessStack: Buffer[]): Buffer[];
+/**
+ * Checks whether the tapscript and control block from a witness stack matches a 32 byte witness
+ * program (aka taproot pubkey) by validating the merkle proof for its inclusion in the taptree.
+ * @param witnessStack a stack of witness elements containing the tapscript and control block
+ * @param expectedTaprootPubkey the 32-byte array containing the witness program (the second
+ * push in the scriptPubKey) which represents a public key according to BIP340 and which we
+ * expect to match the taproot pubkey derived from the control block
+ * @returns `true` if the tapscript matches the witness program, otherwise `false`
+ * @throws if the witness stack does not conform to the BIP 341 script validation rules
+ */
+export declare function isValidTapscript(witnessStack: Buffer[], expectedTaprootPubkey: Buffer): boolean;
+/**
+ * Checks whether an array of buffers can be parsed according to the BIP 341 script validation rules
+ * @param chunks
+ * @returns `true` if `chunks` can be parsed according to the BIP 341 script validation rules, otherwise `false`
+ */
+export declare function isScriptPathSpend(chunks: Buffer[]): boolean;


### PR DESCRIPTION
This adds logic to classify `p2tr` script path spend inputs according to the BIP 341 script validation rules. It also adds validation logic on the `p2tr` payment class to validate that a given witness stack matches the witness program commited to in the output script. It does this by validating the control block and merkle proof for inclusion of the selected tapscript in the taptree committed to in the witness program.

The new input classification and validation logic is tested against the following transaction which uses the script path to spend a taproot input found in the bitcoin signet chain.

https://explorer.bc-2.jp/tx/dda4cb9290415952d93f52518df978d45ae1710e60e711e6786926e99d305ef9?input:1

Lastly, this commit adds a sanity check to the `p2tr` extended validation to ensure there is not a mismatch between the address and output script in the event both are specified.

Ticket: BG-37366