### PR TITLE
feat: export `classify`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
-exports.TransactionBuilder = exports.Transaction = exports.opcodes = exports.Psbt = exports.Block = exports.script = exports.payments = exports.networks = exports.crypto = exports.bip32 = exports.address = exports.ECPair = void 0;
+exports.TransactionBuilder = exports.Transaction = exports.opcodes = exports.Psbt = exports.types = exports.witness = exports.output = exports.input = exports.Block = exports.script = exports.payments = exports.networks = exports.crypto = exports.bip32 = exports.address = exports.ECPair = void 0;
 const bip32 = require('bip32');
 exports.bip32 = bip32;
 const address = require('./address');
@@ -20,6 +20,31 @@ Object.defineProperty(exports, 'Block', {
   enumerable: true,
   get: function() {
     return block_1.Block;
+  },
+});
+var classify_1 = require('./classify');
+Object.defineProperty(exports, 'input', {
+  enumerable: true,
+  get: function() {
+    return classify_1.input;
+  },
+});
+Object.defineProperty(exports, 'output', {
+  enumerable: true,
+  get: function() {
+    return classify_1.output;
+  },
+});
+Object.defineProperty(exports, 'witness', {
+  enumerable: true,
+  get: function() {
+    return classify_1.witness;
+  },
+});
+Object.defineProperty(exports, 'types', {
+  enumerable: true,
+  get: function() {
+    return classify_1.types;
   },
 });
 var psbt_1 = require('./psbt');

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -9,6 +9,7 @@ import * as script from './script';
 export { ECPair, address, bip32, crypto, networks, payments, script };
 
 export { Block } from './block';
+export { input, output, witness, types } from './classify';
 export { Psbt, PsbtTxInput, PsbtTxOutput } from './psbt';
 export { OPS as opcodes } from './script';
 export { Transaction } from './transaction';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@ import * as payments from './payments';
 import * as script from './script';
 export { ECPair, address, bip32, crypto, networks, payments, script };
 export { Block } from './block';
+export { input, output, witness, types } from './classify';
 export { Psbt, PsbtTxInput, PsbtTxOutput } from './psbt';
 export { OPS as opcodes } from './script';
 export { Transaction } from './transaction';


### PR DESCRIPTION
It is kind of a step in the wrong direction: the reason it was not
exported upstream is because `classify` is part of the
TransactionBuilder system and will be removed in `bitcoinjs-lib@6`.

Still, some of BitGo (and utxo-lib) code depends on it so we need to
export it at this point.

Issue: BG-37511