### PR TITLE
fix(taproot): KeyAgg fix selection of ^1 key

### DIFF
--- a/src/taproot.js
+++ b/src/taproot.js
@@ -67,12 +67,14 @@ function aggregateMuSigPubkeys(pubkeys) {
   // L = H(P_1 || P_2 || ... || P_n)
   // µ_i = H(L || P_i)
   const L = taggedHash('KeyAgg list', Buffer.concat(pubkeys));
-  const tweakedPubkeys = pubkeys.map((pubkey, index) => {
+  const secondUniquePubkey = pubkeys.find(pubkey => !pubkeys[0].equals(pubkey));
+  const tweakedPubkeys = pubkeys.map(pubkey => {
     const xyPubkey = Buffer.concat([exports.EVEN_Y_COORD_PREFIX, pubkey]);
-    if (index === 1) {
-      // The second unique key in the pubkey list gets the constant KeyAgg
-      // coefficient 1 which saves an exponentiation. See the MuSig2*
-      // appendix in the MuSig2 paper for details.
+    if (secondUniquePubkey !== undefined && secondUniquePubkey.equals(pubkey)) {
+      // The second unique key in the pubkey list given to ''KeyAgg'' (as well
+      // as any keys identical to this key) gets the constant KeyAgg
+      // coefficient 1 which saves an exponentiation (see the MuSig2* appendix
+      // in the MuSig2 paper).
       return xyPubkey;
     }
     const c = taggedHash('KeyAgg coefficient', Buffer.concat([L, pubkey]));

--- a/ts_src/taproot.ts
+++ b/ts_src/taproot.ts
@@ -74,13 +74,16 @@ export function aggregateMuSigPubkeys(pubkeys: Buffer[]): Buffer {
 
   const L = taggedHash('KeyAgg list', Buffer.concat(pubkeys));
 
-  const tweakedPubkeys: Buffer[] = pubkeys.map((pubkey, index) => {
+  const secondUniquePubkey = pubkeys.find(pubkey => !pubkeys[0].equals(pubkey));
+
+  const tweakedPubkeys: Buffer[] = pubkeys.map(pubkey => {
     const xyPubkey = Buffer.concat([EVEN_Y_COORD_PREFIX, pubkey]);
 
-    if (index === 1) {
-      // The second unique key in the pubkey list gets the constant KeyAgg
-      // coefficient 1 which saves an exponentiation. See the MuSig2*
-      // appendix in the MuSig2 paper for details.
+    if (secondUniquePubkey !== undefined && secondUniquePubkey.equals(pubkey)) {
+      // The second unique key in the pubkey list given to ''KeyAgg'' (as well
+      // as any keys identical to this key) gets the constant KeyAgg
+      // coefficient 1 which saves an exponentiation (see the MuSig2* appendix
+      // in the MuSig2 paper).
       return xyPubkey;
     }
 


### PR DESCRIPTION
* If the first 2 keys are identical, pick the second unique key.
* Per this spec clarification:
https://github.com/ElementsProject/secp256k1-zkp/commit/53608b9835f797a5b0bef1afd835fab2679765bf
Also use the 1 exponent for additional keys identical to the second
unique.