### PR TITLE
feat(psbt): enable psbt finalizer to finalize partially signed psbt tx

### DIFF
--- a/src/payments/index.d.ts
+++ b/src/payments/index.d.ts
@@ -41,6 +41,7 @@ export declare type PaymentFunction = () => Payment;
 export interface PaymentOpts {
     validate?: boolean;
     allowIncomplete?: boolean;
+    minRequiredSigCount?: number;
     eccLib?: TinySecp256k1Interface;
 }
 export declare type StackElement = Buffer | number;

--- a/src/psbt.d.ts
+++ b/src/psbt.d.ts
@@ -81,7 +81,7 @@ export declare class Psbt {
     getFeeRate(): number;
     getFee(): bigint;
     finalizeAllInputs(): this;
-    finalizeInput(inputIndex: number, finalScriptsFunc?: FinalScriptsFunc): this;
+    finalizeInput(inputIndex: number, finalScriptsFunc?: FinalScriptsFunc, minRequiredSigCount?: number): this;
     getInputType(inputIndex: number): AllScriptType;
     inputHasPubkey(inputIndex: number, pubkey: Buffer): boolean;
     inputHasHDKey(inputIndex: number, root: HDSigner): boolean;
@@ -193,7 +193,8 @@ input: PsbtInput, // The PSBT input contents
 script: Buffer, // The "meaningful" locking script Buffer (redeemScript for P2SH etc.)
 isSegwit: boolean, // Is it segwit?
 isP2SH: boolean, // Is it P2SH?
-isP2WSH: boolean) => {
+isP2WSH: boolean, // Is it P2WSH?
+minRequiredSigCount?: number) => {
     finalScriptSig: Buffer | undefined;
     finalScriptWitness: Buffer | undefined;
 };

--- a/ts_src/payments/index.ts
+++ b/ts_src/payments/index.ts
@@ -44,6 +44,7 @@ export type PaymentFunction = () => Payment;
 export interface PaymentOpts {
   validate?: boolean;
   allowIncomplete?: boolean;
+  minRequiredSigCount?: number;
   eccLib?: TinySecp256k1Interface;
 }
 

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -360,6 +360,7 @@ export class Psbt {
   finalizeInput(
     inputIndex: number,
     finalScriptsFunc: FinalScriptsFunc = getFinalScripts,
+    minRequiredSigCount?: number,
   ): this {
     const input = checkForInput(this.data.inputs, inputIndex);
     const { script, isP2SH, isP2WSH, isSegwit } = getScriptFromInput(
@@ -378,6 +379,7 @@ export class Psbt {
       isSegwit,
       isP2SH,
       isP2WSH,
+      minRequiredSigCount,
     );
 
     if (finalScriptSig) this.data.updateInput(inputIndex, { finalScriptSig });
@@ -917,6 +919,7 @@ function canFinalize(
   input: PsbtInput,
   script: Buffer,
   scriptType: string,
+  minRequiredSigCount?: number,
 ): boolean {
   switch (scriptType) {
     case 'pubkey':
@@ -925,7 +928,17 @@ function canFinalize(
       return hasSigs(1, input.partialSig);
     case 'multisig':
       const p2ms = payments.p2ms({ output: script });
-      return hasSigs(p2ms.m!, input.partialSig, p2ms.pubkeys);
+      let m = p2ms.m!;
+      if (p2ms.m !== undefined && minRequiredSigCount !== undefined) {
+        if (p2ms.m < minRequiredSigCount)
+          throw new Error(
+            `minRequiredSigCount=${minRequiredSigCount} is more than m=${
+              p2ms.m
+            }`,
+          );
+        m = minRequiredSigCount;
+      }
+      return hasSigs(m, input.partialSig, p2ms.pubkeys);
     default:
       return false;
   }
@@ -1169,6 +1182,7 @@ type FinalScriptsFunc = (
   isSegwit: boolean, // Is it segwit?
   isP2SH: boolean, // Is it P2SH?
   isP2WSH: boolean, // Is it P2WSH?
+  minRequiredSigCount?: number,
 ) => {
   finalScriptSig: Buffer | undefined;
   finalScriptWitness: Buffer | undefined;
@@ -1181,12 +1195,17 @@ function getFinalScripts(
   isSegwit: boolean,
   isP2SH: boolean,
   isP2WSH: boolean,
+  minRequiredSigCount?: number,
 ): {
   finalScriptSig: Buffer | undefined;
   finalScriptWitness: Buffer | undefined;
 } {
+  if (minRequiredSigCount !== undefined && minRequiredSigCount < 1)
+    throw new Error(
+      `minRequiredSigCount=${minRequiredSigCount} is less than minimum value 1`,
+    );
   const scriptType = classifyScript(script);
-  if (!canFinalize(input, script, scriptType))
+  if (!canFinalize(input, script, scriptType, minRequiredSigCount))
     throw new Error(`Can not finalize input #${inputIndex}`);
   return prepareFinalScripts(
     script,
@@ -1195,6 +1214,7 @@ function getFinalScripts(
     isSegwit,
     isP2SH,
     isP2WSH,
+    minRequiredSigCount,
   );
 }
 
@@ -1205,6 +1225,7 @@ function prepareFinalScripts(
   isSegwit: boolean,
   isP2SH: boolean,
   isP2WSH: boolean,
+  minRequiredSigCount?: number,
 ): {
   finalScriptSig: Buffer | undefined;
   finalScriptWitness: Buffer | undefined;
@@ -1213,7 +1234,12 @@ function prepareFinalScripts(
   let finalScriptWitness: Buffer | undefined;
 
   // Wow, the payments API is very handy
-  const payment: payments.Payment = getPayment(script, scriptType, partialSig);
+  const payment: payments.Payment = getPayment(
+    script,
+    scriptType,
+    partialSig,
+    minRequiredSigCount,
+  );
   const p2wsh = !isP2WSH ? null : payments.p2wsh({ redeem: payment });
   const p2sh = !isP2SH ? null : payments.p2sh({ redeem: p2wsh || payment });
 
@@ -1376,15 +1402,21 @@ function getPayment(
   script: Buffer,
   scriptType: string,
   partialSig: PartialSig[],
+  minRequiredSigCount?: number,
 ): payments.Payment {
   let payment: payments.Payment;
   switch (scriptType) {
     case 'multisig':
       const sigs = getSortedSigs(script, partialSig);
-      payment = payments.p2ms({
-        output: script,
-        signatures: sigs,
-      });
+      payment = payments.p2ms(
+        {
+          output: script,
+          signatures: sigs,
+        },
+        {
+          minRequiredSigCount,
+        },
+      );
       break;
     case 'pubkey':
       payment = payments.p2pk({


### PR DESCRIPTION
Currently PSBT doesn’t support to extract partially signed tx from psbt This change enables to do that in a hacky way and against PSBT spec. Test suite is to be done.

Ex use case - one of the cosigner doesn’t support psbt.

TICKET: BG-58455