### PR TITLE
chore(psbt): psbt clone uses correct fromBuffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,13 +1434,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "bs58check": "^2.1.2",
     "create-hash": "^1.1.0",
     "fastpriorityqueue": "^0.7.1",
+    "json5": "^2.2.3",
     "ripemd160": "^2.0.2",
     "typeforce": "^1.11.3",
     "varuint-bitcoin": "^1.1.2",

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -152,7 +152,7 @@ class Psbt {
   }
   clone() {
     // TODO: more efficient cloning
-    const res = Psbt.fromBuffer(this.data.toBuffer());
+    const res = this.constructor.fromBuffer(this.data.toBuffer(), this.opts);
     res.opts = JSON.parse(JSON.stringify(this.opts));
     return res;
   }

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -216,7 +216,10 @@ export class Psbt {
 
   clone(): Psbt {
     // TODO: more efficient cloning
-    const res = Psbt.fromBuffer(this.data.toBuffer());
+    const res = (this.constructor as typeof Psbt).fromBuffer(
+      this.data.toBuffer(),
+      this.opts,
+    );
     res.opts = JSON.parse(JSON.stringify(this.opts));
     return res;
   }


### PR DESCRIPTION
Enables extension of Psbt to support other chains

Additionally, it patches [Json5 vulnerability](https://github.com/advisories/GHSA-9c47-m6qq-7p4h).

Ticket: BG-00000