### PR TITLE
fix(psbt): do not use BIP174 tobuffer method in clone by default

### DIFF
--- a/src/psbt.js
+++ b/src/psbt.js
@@ -152,7 +152,7 @@ class Psbt {
   }
   clone() {
     // TODO: more efficient cloning
-    const res = this.constructor.fromBuffer(this.data.toBuffer(), this.opts);
+    const res = this.constructor.fromBuffer(this.toBuffer(), this.opts);
     res.opts = JSON.parse(JSON.stringify(this.opts));
     return res;
   }

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -896,6 +896,20 @@ describe(`Psbt`, () => {
       assert.notStrictEqual(clone.toBase64(), notAClone.toBase64());
       assert.strictEqual(psbt.toBase64(), notAClone.toBase64());
     });
+
+    it('Should use the proper toBuffer method when cloning', () => {
+      class PsbtSubclass extends Psbt {
+        toBuffer(): Buffer {
+          super.setLocktime(1000);
+          return super.toBuffer();
+        }
+      }
+      const psbt = new PsbtSubclass();
+      assert.strictEqual(psbt.extractTransaction().locktime, 0);
+
+      const clone = psbt.clone();
+      assert.strictEqual(clone.extractTransaction().locktime, 1000);
+    });
   });
 
   describe('setMaximumFeeRate', () => {

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -217,7 +217,7 @@ export class Psbt {
   clone(): Psbt {
     // TODO: more efficient cloning
     const res = (this.constructor as typeof Psbt).fromBuffer(
-      this.data.toBuffer(),
+      this.toBuffer(),
       this.opts,
     );
     res.opts = JSON.parse(JSON.stringify(this.opts));


### PR DESCRIPTION
We want to use the `toBuffer` methods that we implement in child classes of PSBT, not just the bip174 serialization. For the PSBT class, this will automatically default to bip174 serialization.