### PR TITLE
feat: pass bip32PathsAbsolute flag into bip174

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -595,9 +595,9 @@
       "dev": true
     },
     "bip174": {
-      "version": "npm:@bitgo/bip174@3.0.0",
-      "resolved": "https://registry.npmjs.org/@bitgo/bip174/-/bip174-3.0.0.tgz",
-      "integrity": "sha512-Qv98vy6l1WgZwrxKx7IPYY91/+Z3tpALVSDn+Ic9qCsxygCq9gYw5eL8q3kd7LYTFLy/HgcqhcMOa83Spbp4JA=="
+      "version": "npm:@bitgo-forks/bip174@3.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@bitgo-forks/bip174/-/bip174-3.0.0-rc.1.tgz",
+      "integrity": "sha512-eGi5die7Q7O3yPtkcGF1gD7qLlJLiLnYI4DpFTF6tUhUo71gy3RoXAAeeJA2fLpnVoJofXnLdLfpcO6OEZAsvw=="
     },
     "bip32": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "bech32": "^2.0.0",
-    "bip174": "npm:@bitgo/bip174@3.0.0",
+    "bip174": "npm:@bitgo-forks/bip174@3.0.0-rc.1",
     "bs58check": "^2.1.2",
     "create-hash": "^1.1.0",
     "fastpriorityqueue": "^0.7.1",

--- a/src/psbt.d.ts
+++ b/src/psbt.d.ts
@@ -53,9 +53,9 @@ export declare type ValidateSigFunction = (pubkey: Buffer, msghash: Buffer, sign
  */
 export declare class Psbt {
     readonly data: PsbtBase;
-    static fromBase64(data: string, opts?: PsbtOptsOptional): Psbt;
-    static fromHex(data: string, opts?: PsbtOptsOptional): Psbt;
-    static fromBuffer(buffer: Buffer, opts?: PsbtOptsOptional): Psbt;
+    static fromBase64(data: string, opts?: PsbtDeserializeOptsOptional): Psbt;
+    static fromHex(data: string, opts?: PsbtDeserializeOptsOptional): Psbt;
+    static fromBuffer(buffer: Buffer, opts?: PsbtDeserializeOptsOptional): Psbt;
     protected static transactionFromBuffer(buffer: Buffer, _network: Network): Transaction<bigint>;
     private __CACHE;
     private opts;
@@ -111,6 +111,9 @@ export declare class Psbt {
 interface PsbtOptsOptional {
     network?: Network;
     maximumFeeRate?: number;
+}
+interface PsbtDeserializeOptsOptional extends PsbtOptsOptional {
+    bip32PathsAbsolute?: boolean;
 }
 interface PsbtInputExtended extends PsbtInput, TransactionInput {
 }

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -100,7 +100,9 @@ class Psbt {
     return this.fromBuffer(buffer, opts);
   }
   static fromBuffer(buffer, opts = {}) {
-    const psbtBase = bip174_1.Psbt.fromBuffer(buffer, transactionFromBuffer);
+    const psbtBase = bip174_1.Psbt.fromBuffer(buffer, transactionFromBuffer, {
+      bip32PathsAbsolute: opts.bip32PathsAbsolute,
+    });
     const psbt = new Psbt(opts, psbtBase);
     checkTxForDupeIns(psbt.__CACHE.__TX, psbt.__CACHE);
     return psbt;

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -396,6 +396,30 @@ describe(`Psbt`, () => {
     });
   });
 
+  describe('deserialization', () => {
+    [true, false].forEach((bip32PathsAbsolute: boolean) => {
+      it(`bip32Derivation paths are ${
+        bip32PathsAbsolute ? '' : 'not'
+      } absolute`, async () => {
+        const psbt = Psbt.fromBase64(
+          fixtures.signInputHD.checks[0].shouldSign.psbt,
+          { bip32PathsAbsolute },
+        );
+        const input = psbt.data.inputs[0];
+        assert(input);
+        const bip32Derivations = input.bip32Derivation;
+        assert(bip32Derivations);
+        const bip32Derivation = bip32Derivations[0];
+        assert(bip32Derivation);
+        const pathString = bip32Derivation.path;
+        assert(pathString);
+        const path = pathString.split('/');
+        const bip32PathPrefix = bip32PathsAbsolute ? 'm' : `44'`;
+        assert(path[0] === bip32PathPrefix);
+      });
+    });
+  });
+
   describe('signAllInputsHDAsync', () => {
     fixtures.signInputHD.checks.forEach(f => {
       it(f.description, async () => {

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -97,18 +97,26 @@ const DEFAULT_OPTS: PsbtOpts = {
  *   Transaction object. Such as fee rate not being larger than maximumFeeRate etc.
  */
 export class Psbt {
-  static fromBase64(data: string, opts: PsbtOptsOptional = {}): Psbt {
+  static fromBase64(
+    data: string,
+    opts: PsbtDeserializeOptsOptional = {},
+  ): Psbt {
     const buffer = Buffer.from(data, 'base64');
     return this.fromBuffer(buffer, opts);
   }
 
-  static fromHex(data: string, opts: PsbtOptsOptional = {}): Psbt {
+  static fromHex(data: string, opts: PsbtDeserializeOptsOptional = {}): Psbt {
     const buffer = Buffer.from(data, 'hex');
     return this.fromBuffer(buffer, opts);
   }
 
-  static fromBuffer(buffer: Buffer, opts: PsbtOptsOptional = {}): Psbt {
-    const psbtBase = PsbtBase.fromBuffer(buffer, transactionFromBuffer);
+  static fromBuffer(
+    buffer: Buffer,
+    opts: PsbtDeserializeOptsOptional = {},
+  ): Psbt {
+    const psbtBase = PsbtBase.fromBuffer(buffer, transactionFromBuffer, {
+      bip32PathsAbsolute: opts.bip32PathsAbsolute,
+    });
     const psbt = new Psbt(opts, psbtBase);
     checkTxForDupeIns(psbt.__CACHE.__TX, psbt.__CACHE);
     return psbt;
@@ -773,6 +781,10 @@ interface PsbtCache {
 interface PsbtOptsOptional {
   network?: Network;
   maximumFeeRate?: number;
+}
+
+interface PsbtDeserializeOptsOptional extends PsbtOptsOptional {
+  bip32PathsAbsolute?: boolean;
 }
 
 interface PsbtOpts {


### PR DESCRIPTION
* Bump `bip174`
* Pass in `bip32PathsAbsolute` flag for PSBT deserialization


[BG-54756](https://bitgoinc.atlassian.net/browse/BG-54756)

[BG-54756]: https://bitgoinc.atlassian.net/browse/BG-54756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ