### PR TITLE
chore: specify git protocol in repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/BitGo/bitcoinjs-lib.git"
+    "url": "git+https://github.com/BitGo/bitcoinjs-lib.git"
   },
   "files": [
     "src"


### PR DESCRIPTION
semantic-release uses the `repository` url in package.json as its
`repositoryUrl` setting[^1].

I believe not specifying the `git+` prefix is causing this release
error[^2]:

```
[2:22:18 PM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication (https://api.github.com)
[2:22:18 PM] [semantic-release] [@semantic-release/github] › ℹ  Skip issue creation.
[2:22:18 PM] [semantic-release] › ✖  EGITNOPERMISSION Cannot push to the Git repository.
[2:22:18 PM] [semantic-release] › ✔  Completed step "fail" of plugin "@semantic-release/github"
semantic-release cannot push the version tag to the branch master on the remote Git repository with URL https://x-access-token:[secure]@github.com/BitGo/bitcoinjs-lib.git.

This can be caused by:

    * a misconfiguration of the repositoryUrl (https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#repositoryurl) option
    * the repository being unavailable
    * or missing push permission for the user configured via the Git credentials on your CI environment (https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication)

SemanticReleaseError: Cannot push to the Git repository.
```

[^1]: https://semantic-release.gitbook.io/semantic-release/usage/configuration#repositoryurl
[^2]: https://github.com/BitGo/bitcoinjs-lib/actions/runs/3997126174/jobs/6858073731