### PR TITLE
ci: grant write permissions to GitHub Actions

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   ##################


### PR DESCRIPTION
semantic-release needs to be able to create git tags, so promote
the `contents` permission from `read` to `write` as indicated in
https://github.com/semantic-release/semantic-release/issues/2496#issuecomment-1329729857