### PR TITLE
fix: correct renovate path and release version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,15 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>BitGo/gha-renovate-bot//presets/onboarding#0.0.1"
+    "github>BitGo/gha-renovate-bot//presets/onboarding#v1.15.1"
   ],
   "baseBranches": [
     "master"
   ],
   "enabledManagers": [
     "github-actions"
-  ],
-  "schedule": [
-    "on monday"
   ]
 }


### PR DESCRIPTION
This commit corrects release version to enable updates and moves to .github folder. It also removes schedule as its driven centrally